### PR TITLE
Fix Travis CI Gem::InstallError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@
 sudo: false
 language: ruby
 rvm:
-- 2.1.7
-- 2.2
 - 2.3.0
 matrix:
   include:
-    - rvm: 2.1.7
+    - rvm: 2.3.0
       env: BUNTO_VERSION=1.0
-    - rvm: 2.1.7
+    - rvm: 2.3.0
       env: GH_PAGES=1
 env:
   matrix:


### PR DESCRIPTION
Gem::InstallError: listen requires Ruby version >= 2.2.3, ~> 2.2.
